### PR TITLE
add baseUrl to group fetch

### DIFF
--- a/src/client/views/dashboard.vue
+++ b/src/client/views/dashboard.vue
@@ -42,6 +42,8 @@
     import { getEvents } from '../utils'
     import xIcon from '../icons/x.svg'
     import _ from 'lodash'
+    
+    const baseURL = process.env.BASE_URL || 'https://www.ithacawebpeople.com'
 
     export default {
         name: 'dashboard',
@@ -65,7 +67,7 @@
         },
         methods: {
             async setGroup () {
-                const json = await fetch('/api/groups').then(r => r.json())
+                const json = await fetch(`${baseURL}/api/groups`).then(r => r.json())
                 this.group = _.first(json.data)
             },
             delayLoad (key) {


### PR DESCRIPTION
The setGroup method was calling the api locally so the call failed when running locally resulting in a large empty space where the group description is supposed to be. Added baseUrl so the calls fallback to the ithacawebpeople.com api.

![screencapture-ith-incogleto-c9users-io-8080-1505196329918](https://user-images.githubusercontent.com/13292186/30310513-e3d90ea0-975e-11e7-95d4-20c8aa6475c0.png)